### PR TITLE
Add docs for batch and text operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
 .cursor/
 dist/
-docs/

--- a/docs/BATCH_OPERATIONS.md
+++ b/docs/BATCH_OPERATIONS.md
@@ -1,0 +1,22 @@
+# Batch Operations Guide
+
+## Purpose
+
+Speed up repetitive tasks and reduce API calls by processing groups of nodes at once. Large documents often cause timeouts if handled individually.
+
+## Recommended Tools
+
+- `clone_multiple_nodes` - Clone a node to many positions in a single operation
+- `get_multiple_nodes_info` - Retrieve details for many nodes at once
+- `set_multiple_nodes_property` - Change the same property on multiple nodes
+- `execute_batch` - Run a sequence of commands with a single round-trip
+- `get_connection_status` - Monitor progress and current status
+- Use `scan_nodes_with_options` to limit depth for huge documents
+
+## Examples
+
+- Cloning 20 nodes dropped from 50s to 5s using `clone_multiple_nodes`
+- Updating 112 text nodes went from 15 minutes to 30s when batched
+- Combining text and formatting updates into one call saves roughly 50% API calls
+
+Refer to the performance table in the README for real metrics.

--- a/docs/ENHANCED_TEXT_OPERATIONS.md
+++ b/docs/ENHANCED_TEXT_OPERATIONS.md
@@ -1,0 +1,18 @@
+# Enhanced Text Operations Guide
+
+## Purpose
+
+Perform text replacement or updates without losing formatting. Useful for large documents containing mixed styles and fonts.
+
+## Recommended Tools
+
+- `update_text_preserve_formatting` - Replace text while keeping existing styles
+- `smart_text_replace` - Find and replace with formatting preservation
+- `set_multiple_text_contents_with_styles` - Batch update text and styles together
+
+## Examples
+
+- Use `smart_text_replace` to swap labels while keeping bold and color settings
+- Apply `set_multiple_text_contents_with_styles` to update many headings in one request
+
+These APIs help maintain brand styling and avoid manual corrections after updates.

--- a/docs/FONT_HANDLING.md
+++ b/docs/FONT_HANDLING.md
@@ -1,0 +1,20 @@
+# Font Handling Documentation
+
+## Purpose
+
+Avoid "Cannot unwrap symbol" errors and maintain consistency when working with text nodes that use multiple fonts.
+
+## Recommended Tools
+
+- `getRangeAllFontNames()` - Identify fonts used in a text range before updates
+- Load fonts in bulk with `Promise.allSettled` to handle missing fonts gracefully
+- Use logging to debug problematic font families
+- Combine with text operations like `update_text_preserve_formatting` for mixed-font content
+
+## Examples
+
+1. Call `getRangeAllFontNames()` to collect fonts from a node.
+2. Load each font before running text replacement commands.
+3. If a font fails to load, logs will note the issue so you can choose a fallback.
+
+Following these steps prevents mixed-font updates from throwing errors.

--- a/docs/TEXT_STYLING.md
+++ b/docs/TEXT_STYLING.md
@@ -1,0 +1,20 @@
+# Text Styling Guide
+
+## Purpose
+
+Apply rich formatting to specific ranges of text and extract style information for advanced automation.
+
+## Recommended Tools
+
+- `set_text_style_range` and `get_text_style_range` for basic styles like bold or italic
+- `set_text_decoration_range` and `get_text_decoration_range` for underline or strikethrough
+- `set_range_font` and `set_range_font_size` to change fonts and sizes
+- `set_range_fills` to apply colors
+- `get_styled_text_segments` for a detailed breakdown of styled segments
+- `set_component_description` and `get_component_description` for markdown-based descriptions
+- `normalize_markdown` to convert common Markdown to Figma's subset
+
+## Examples
+
+- Change the font of a word while leaving the rest untouched using `set_range_font`
+- Retrieve styling of a paragraph via `get_styled_text_segments` to replicate it elsewhere

--- a/readme.md
+++ b/readme.md
@@ -13,14 +13,14 @@ This is an independent project and is not affiliated with, officially maintained
 ## Key Enhancements
 
 ### v0.3.2 (Latest)
-- **Text Formatting Preservation** - Text updates no longer lose formatting (bold, italic, colors, fonts)
-- **Batch Operations** - 50-90% performance improvement for bulk operations
+- **Text Formatting Preservation** - Text updates no longer lose formatting (bold, italic, colors, fonts). See [Enhanced Text Operations Guide](docs/ENHANCED_TEXT_OPERATIONS.md).
+- **Batch Operations** - 50-90% performance improvement for bulk operations. See [Batch Operations Guide](docs/BATCH_OPERATIONS.md).
 - **Enhanced Error Handling** - Specific, actionable error messages with suggestions
 - **Timeout Solutions** - New scanning options with depth control and partial results
 - **Smart Text Operations** - Find/replace with formatting preservation
 
 ### Previous Enhancements
-- **Fixed "Cannot unwrap symbol" error** when working with mixed fonts
+- **Fixed "Cannot unwrap symbol" error** when working with mixed fonts. See [Font Handling Documentation](docs/FONT_HANDLING.md).
 - **Improved font loading** with `getRangeAllFontNames()` API
 - **Better error handling** with `Promise.allSettled()` for font loading
 - **Safe value returns** to avoid serialization issues
@@ -187,11 +187,13 @@ The MCP server provides the following tools for interacting with Figma:
 - `set_multiple_text_contents` - Batch update multiple text nodes efficiently (Note: loses formatting)
 
 #### Text with Formatting Preservation (v0.3.2)
+See [Enhanced Text Operations Guide](docs/ENHANCED_TEXT_OPERATIONS.md) for an overview.
 - `update_text_preserve_formatting` - Update text while preserving all character formatting (bold, italic, colors, fonts)
 - `smart_text_replace` - Find and replace text while preserving formatting of unchanged portions
 - `set_multiple_text_contents_with_styles` - Batch update text with formatting in a single operation
 
 #### Text Styling
+See [Text Styling Guide](docs/TEXT_STYLING.md) for detailed usage.
 - `set_text_style_range` - Apply text styling (bold, italic, underline, strikethrough) to specific character ranges
 - `get_text_style_range` - Get text styling for a specific range
 - `set_text_decoration_range` - Set advanced text decoration properties
@@ -227,6 +229,7 @@ The MCP server provides the following tools for interacting with Figma:
 - `clone_node` - Create a copy of an existing node with optional position offset
 
 ### Batch Operations (v0.3.2)
+See [Batch Operations Guide](docs/BATCH_OPERATIONS.md) for best practices.
 
 - `clone_multiple_nodes` - Clone a node to multiple positions in one operation (50-90% faster than individual clones)
 - `get_multiple_nodes_info` - Get information for multiple nodes in a single request


### PR DESCRIPTION
## Summary
- document font handling, batch operations, text styling, and enhanced text operations
- remove docs/ from `.gitignore`
- reference new guides throughout the README

## Testing
- `npm test` *(fails: Missing script)*
- `bun test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd010e5bc832a8560f56316a74ae7